### PR TITLE
feat: 서치바 mainController와 연결

### DIFF
--- a/ios5-Movie/ios5-Movie/MainView/MovieListViewController.swift
+++ b/ios5-Movie/ios5-Movie/MainView/MovieListViewController.swift
@@ -187,10 +187,11 @@ class MovieListViewController: UIViewController {
             
         /// 영화검색 페이지
         case 1:
-            let searchVC = SearchListViewController()
-            addChild(searchVC)
-            selectedView = searchVC.view
-            searchVC.didMove(toParent: self)
+            let searchVC = SearchBarViewController()
+            let setNavBarForSearchBar = UINavigationController(rootViewController: searchVC)
+            addChild(setNavBarForSearchBar)
+            selectedView = setNavBarForSearchBar.view
+            setNavBarForSearchBar.didMove(toParent: self)
             
         /// 마이페이지
         case 2:

--- a/ios5-Movie/ios5-Movie/SearchView/MovieSearchCell.swift
+++ b/ios5-Movie/ios5-Movie/SearchView/MovieSearchCell.swift
@@ -16,7 +16,6 @@ class MovieSearchCell: UICollectionViewCell {
     // 영화 포스터 이미지뷰
     var posterImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     
@@ -24,8 +23,8 @@ class MovieSearchCell: UICollectionViewCell {
     var titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.font = .systemFont(ofSize: 14)
-        label.numberOfLines = 1
+        label.font = .boldSystemFont(ofSize: 14)
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()
@@ -38,7 +37,7 @@ class MovieSearchCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+    //네트워크 통신을 통해 셀 설정
     func setupCell(with movie: Movie) {
         
         if let posterPath = movie.posterPath {
@@ -66,17 +65,13 @@ class MovieSearchCell: UICollectionViewCell {
         // 오토레이아웃 설정
         posterImageView.snp.makeConstraints {
             $0.top.left.right.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(20)
             $0.height.equalTo(posterImageView.snp.width).multipliedBy(1.5) // 3:2 비율
         }
         titleLabel.snp.makeConstraints {
-            $0.bottom.equalTo(posterImageView.snp.bottom).offset(5)
             $0.top.equalTo(posterImageView.snp.bottom).offset(0)
+            $0.bottom.equalToSuperview()
             $0.left.right.equalToSuperview()
         }
     }
-}
-
-@available(iOS 17.0, *)
-#Preview {
-    MovieListViewController()
 }

--- a/ios5-Movie/ios5-Movie/SearchView/SearchBarViewController.swift
+++ b/ios5-Movie/ios5-Movie/SearchView/SearchBarViewController.swift
@@ -9,11 +9,22 @@ import UIKit
 import SnapKit
 
 class SearchBarViewController: UIViewController, UISearchBarDelegate {
-
+    
+    //서치 컨트롤러 기본 설정
+    private lazy var searchController: UISearchController = {
+        //검색화면을 담당하는 VC
+        let searchController = UISearchController(searchResultsController: SearchListViewController())
+        searchController.searchBar.placeholder = "영화 이름 검색"
+        
+        return searchController
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavBar()
         setupSearchController()
+        //네비게이션 바 위치 조정
+        navigationController?.navigationBar.transform = CGAffineTransform(translationX: 0, y: -10)
     }
     
     //네비게이션 바 설정
@@ -24,14 +35,6 @@ class SearchBarViewController: UIViewController, UISearchBarDelegate {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = true
     }
-    
-    //서치 컨트롤러 기본 설정
-    private lazy var searchController: UISearchController = {
-        let searchController = UISearchController(searchResultsController: SearchListViewController())
-        searchController.searchBar.placeholder = "영화 이름 검색"
-        
-        return searchController
-    }()
     
     //서치바 델리게이트 설정
     private func setupSearchController() {
@@ -50,15 +53,4 @@ extension SearchBarViewController {
                 }
         print("\(searchText)")
     }
-    //서치바내 취소버튼 눌리면 실행되는 동작
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        print("취소버튼 눌림")
-    }
 }
-
-//@available(iOS 17.0, *)
-//#Preview {
-//    let searchVC = SearchViewController()
-//    let navigationController = UINavigationController(rootViewController: searchVC)
-//    return navigationController
-//}

--- a/ios5-Movie/ios5-Movie/SearchView/SearchListViewController.swift
+++ b/ios5-Movie/ios5-Movie/SearchView/SearchListViewController.swift
@@ -69,8 +69,3 @@ extension SearchListViewController: UICollectionViewDataSource, UICollectionView
         return CGSize(width: width, height: width * 1.5)
     }
 }
-
-//@available(iOS 17.0, *)
-//#Preview {
-//    MovieListSearchViewController()
-//}


### PR DESCRIPTION
![Simulator Screenshot - iPhone 16 - 2024-12-19 at 18 44 55](https://github.com/user-attachments/assets/ceb3193e-4fef-4ed1-8539-371a61377368)
![Simulator Screenshot - iPhone 16 - 2024-12-19 at 18 45 24](https://github.com/user-attachments/assets/a940cd2d-9f19-430f-b5df-236c094b6308)

## MainVC와 화면 연결
서치 컨트롤러의 겅우는 네비게이션 바에 탑재가 되어 있어 부득이 하게 네비바를 추가적으로 추가했습니다.

## MovieSearchCell 수정
* 레이블 규약이 부족해서 레이블 규약 설정을 추가해줬습니다.
* 영화제목이 길면 레이블이 짤리는 현상을 발견해 레이블의 너비값에 따라 폰트크기가 변경되는 설정을 추가했습니다.

## SearchBarViewController 수정
* 세그먼트 컨트롤러와 간격을 줄여달라는 피드백을 받아 서치바가 있는 네비바의 y축 위치를 10정도 위로 올렸습니다.

## 그외
* 주석추가, 필요없는 코드 삭제
